### PR TITLE
Fixes HTTPS mixed content in the map

### DIFF
--- a/app/views/partials/_map_modal.html.haml
+++ b/app/views/partials/_map_modal.html.haml
@@ -8,7 +8,7 @@
       %br/
       %small
         // TODO: localize
-        %a{:href => "http://www.openstreetmap.org/?mlat=40.33249&amp;mlon=-3.76728#map=17/40.33250/-3.76729&amp;layers=N"} Ver mapa más grande
+        %a{:href => "https://www.openstreetmap.org/?mlat=40.33249&amp;mlon=-3.76728#map=17/40.33250/-3.76729&amp;layers=N"} Ver mapa más grande
   .large-6.columns
     .row
       .small-1.columns


### PR DESCRIPTION
While opening any talk, the map is loaded via `http` while the main page is loaded using `https`.
The OpenStreetMap's map is not displayed per as safety measure.
This is the message prompted in Chrome's console:
![image](https://cloud.githubusercontent.com/assets/959128/19839424/a45e7948-9ee1-11e6-845c-ceb75f8e631c.png)

Review? @rmed @mvaello :)
