### PR TITLE
Test Ruby 2.4.1 and simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 cache: bundler
 rvm:
   - 2.3.1
-  - 2.4.0
+  - 2.4.1
 notifications:
   email: false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
-sudo: false
 language: ruby
+sudo: false
+cache: bundler
 rvm:
   - 2.3.1
-
-script:
-  - bundle exec rake db:drop RAILS_ENV=test
-  - bundle exec rake db:create db:migrate RAILS_ENV=test
-  - bundle exec rake db:seed RAILS_ENV=test
-  - bundle exec rake test RAILS_ENV=test
-
-bundler_args: --without production --jobs=3
-
+  - 2.4.0
 notifications:
   email: false
 
-cache: bundler
-sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '>= 2.3.1'
 
 # TODO(javierhonduco): haven't uploaded to bleeding-edge
 # Rails, 5.1.1, because of routing imcompatibilities


### PR DESCRIPTION
Reduces clutter from our .travis.yml and test on Ruby 2.4.1 as well